### PR TITLE
Added a optional button in the header to clear the filter directly

### DIFF
--- a/FilterDataGrid/FilterDataGrid.cs
+++ b/FilterDataGrid/FilterDataGrid.cs
@@ -772,7 +772,7 @@ namespace FilterDataGrid
             {
                 // the previously selected button from the popup is replaced with the new filter column where the clicked clearFilterButton is located
                 button = VisualTreeHelpers.FindChild<Button>(((FrameworkElement)clickedButton.Parent).Parent, "filterButton");
-                pathFilterIcon = VisualTreeHelpers.FindChild<Path>(clickedButton.Parent, "PathFilterIcon");
+                pathFilterIcon = VisualTreeHelpers.FindChild<Path>(button, "PathFilterIcon");
                 clearFilterButton = clickedButton;
 
                 var header = VisualTreeHelpers.FindAncestor<DataGridColumnHeader>(button);

--- a/FilterDataGrid/FilterDataGrid.cs
+++ b/FilterDataGrid/FilterDataGrid.cs
@@ -771,7 +771,7 @@ namespace FilterDataGrid
             if (e.OriginalSource is Button clickedButton && clickedButton.Name == "clearFilterButton" && clearFilterButton != clickedButton)
             {
                 // the previously selected button from the popup is replaced with the new filter column where the clicked clearFilterButton is located
-                button = VisualTreeHelpers.FindChild<Button>(clickedButton.Parent, "filterButton");
+                button = VisualTreeHelpers.FindChild<Button>(((FrameworkElement)clickedButton.Parent).Parent, "filterButton");
                 pathFilterIcon = VisualTreeHelpers.FindChild<Path>(clickedButton.Parent, "PathFilterIcon");
                 clearFilterButton = clickedButton;
 

--- a/FilterDataGrid/FilterDataGrid.xaml
+++ b/FilterDataGrid/FilterDataGrid.xaml
@@ -290,7 +290,7 @@
                         BorderThickness="1"
                         Command="{x:Static control:FilterDataGrid.RemoveFilter}"
                         Cursor="Hand"
-                        Opacity="0.5"
+                        Opacity="1"
                         SnapsToDevicePixels="True"
                         UseLayoutRounding="True"
                         Visibility="Collapsed">
@@ -299,15 +299,15 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="{x:Type Button}">
-                                            <Border Margin="-3,0,0,0"
-                                                    Padding="1"
+                                            <Border Margin="-8,0,0,0"
+                                                    Padding="2"
                                                     Background="{TemplateBinding Background}"
                                                     BorderBrush="{TemplateBinding BorderBrush}"
                                                     BorderThickness="1"
                                                     SnapsToDevicePixels="True"
                                                     ToolTip="{Binding Translate.ClearFilter, RelativeSource={RelativeSource AncestorType={x:Type control:FilterDataGrid}}}"
                                                     UseLayoutRounding="True">
-                                                <Path x:Name="PathFilterClearIcon" Width="16" Data="{StaticResource FilterDelete}" Fill="Black" Stretch="Uniform" />
+                                                <Path x:Name="PathFilterClearIcon" Width="14" Data="{StaticResource FilterDelete}" Fill="Black" Stretch="Uniform" />
                                             </Border>
                                         </ControlTemplate>
                                     </Setter.Value>

--- a/FilterDataGrid/FilterDataGrid.xaml
+++ b/FilterDataGrid/FilterDataGrid.xaml
@@ -305,8 +305,16 @@
                                                     BorderBrush="{TemplateBinding BorderBrush}"
                                                     BorderThickness="1"
                                                     SnapsToDevicePixels="True"
-                                                    ToolTip="{Binding Translate.ClearFilter, RelativeSource={RelativeSource AncestorType={x:Type control:FilterDataGrid}}}"
                                                     UseLayoutRounding="True">
+                                                <Border.ToolTip>
+                                                    <MultiBinding Converter="{StaticResource StringFormatConverter}">
+                                                        <MultiBinding.Bindings>
+                                                            <Binding Path="Translate.Clear" RelativeSource="{RelativeSource AncestorType={x:Type control:FilterDataGrid}}"
+                                                                     TargetNullValue="" UpdateSourceTrigger="PropertyChanged" />
+                                                            <Binding ElementName="ClearFilterBnt" Path="Content" />
+                                                        </MultiBinding.Bindings>
+                                                    </MultiBinding>
+                                                </Border.ToolTip>
                                                 <Path x:Name="PathFilterClearIcon" Width="14" Data="{StaticResource FilterDelete}" Fill="Black" Stretch="Uniform" />
                                             </Border>
                                         </ControlTemplate>

--- a/FilterDataGrid/FilterDataGrid.xaml
+++ b/FilterDataGrid/FilterDataGrid.xaml
@@ -7,6 +7,7 @@
 
     <!--  STRING FORMAT CONVERTER  -->
     <control:StringFormatConverter x:Key="StringFormatConverter" />
+    <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 
     <!--  INITIAL POPUP SIZE  -->
     <sys:Double x:Key="PopupHeight">400</sys:Double>
@@ -126,7 +127,7 @@
                 <ScrollViewer
                     x:Name="DG_ScrollViewer"
                     Grid.Row="0"
-                    CanContentScroll="True"
+                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                     Focusable="false">
                     <ScrollViewer.Template>
                         <ControlTemplate TargetType="{x:Type ScrollViewer}">
@@ -274,15 +275,51 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <!--  RENDER THE HEADER TEXT  -->
-                <TextBlock Grid.Column="0" Text="{Binding}" />
+                <TextBlock Grid.Column="0" Text="{Binding}" Margin="0,0,10,0" />
 
+                <StackPanel Grid.Column="1" Visibility="{Binding ShowClearFilterButton, FallbackValue=Collapsed, Converter={StaticResource BoolToVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type control:FilterDataGrid}}}">
+                    <!--  BUTTON CLEAR FILTER  only shown with option ShowClearFilterButton -->
+                    <Button
+                        Name="clearFilterButton"
+                        Background="Transparent"
+                        BorderBrush="DarkGray"
+                        BorderThickness="1"
+                        Command="{x:Static control:FilterDataGrid.RemoveFilter}"
+                        Cursor="Hand"
+                        Opacity="0.5"
+                        SnapsToDevicePixels="True"
+                        UseLayoutRounding="True"
+                        Visibility="Collapsed">
+                        <Button.Style>
+                            <Style TargetType="{x:Type Button}">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="{x:Type Button}">
+                                            <Border Margin="-3,0,0,0"
+                                                    Padding="1"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="1"
+                                                    SnapsToDevicePixels="True"
+                                                    ToolTip="{Binding Translate.ClearFilter, RelativeSource={RelativeSource AncestorType={x:Type control:FilterDataGrid}}}"
+                                                    UseLayoutRounding="True">
+                                                <Path x:Name="PathFilterClearIcon" Width="16" Data="{StaticResource FilterDelete}" Fill="Black" Stretch="Uniform" />
+                                            </Border>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                </StackPanel>
                 <!--  FILTER BUTTON  -->
                 <Button
                     Name="filterButton"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     Width="19"
                     Height="19"
                     Background="Transparent"

--- a/FilterDataGrid/Loc.cs
+++ b/FilterDataGrid/Loc.cs
@@ -70,10 +70,22 @@ namespace FilterDataGrid
                     "Clear filter \"{0}\"",
                     "Effacer le filtre \"{0}\"",
                     "Очистить фильтр \"{0}\"",
-                    "Filter löschen \"{0}\"",
+                    "Filter \"{0}\" löschen",
                     "Cancella filtro \"{0}\"",
                     "清除过滤器 \"{0}\"",
                     "Filter \"{0}\" verwijderen"
+                }
+            },
+            {
+                "ClearFilter", new[]
+                {
+                    "Clear filter",
+                    "Effacer le filtre",
+                    "Очистить фильтр",
+                    "Filter löschen",
+                    "Cancella filtro",
+                    "清除过滤器",
+                    "Filter verwijderen"
                 }
             },
             {
@@ -118,7 +130,7 @@ namespace FilterDataGrid
                     "{0:n0} record(s) found on {1:n0}",
                     "{0:n0} enregistrement(s) trouvé(s) sur {1:n0}",
                     "{0:n0} записей найдено на {1:n0}",
-                    "{0:n0} zeilen angezeigt von {1:n0}",
+                    "{0:n0} Zeilen angezeigt von {1:n0}",
                     "{0:n0} record trovati su {1:n0}",
                     "{0:n0} 找到了 {1:n0} 条记录",
                     "{0:n0} rij(en) gevonden op {1:n0}",
@@ -156,6 +168,8 @@ namespace FilterDataGrid
         public string Cancel => Translation["Cancel"][Language];
 
         public string Clear => Translation["Clear"][Language];
+
+        public string ClearFilter => Translation["ClearFilter"][Language];
 
         public CultureInfo Culture { get; set; }
 

--- a/FilterDataGrid/Loc.cs
+++ b/FilterDataGrid/Loc.cs
@@ -77,18 +77,6 @@ namespace FilterDataGrid
                 }
             },
             {
-                "ClearFilter", new[]
-                {
-                    "Clear filter",
-                    "Effacer le filtre",
-                    "Очистить фильтр",
-                    "Filter löschen",
-                    "Cancella filtro",
-                    "清除过滤器",
-                    "Filter verwijderen"
-                }
-            },
-            {
                 "Search", new[]
                 {
                     "Search (contains)",
@@ -168,8 +156,6 @@ namespace FilterDataGrid
         public string Cancel => Translation["Cancel"][Language];
 
         public string Clear => Translation["Clear"][Language];
-
-        public string ClearFilter => Translation["ClearFilter"][Language];
 
         public CultureInfo Culture { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To understand how the filter works, you can consult the article posted on [CodeP
 	  - **Control**   
 		```xml 
 		<control:FilterDataGrid 
-		 FilterLanguage="English" DateFormatString="d" ShowStatusBar="True" ShowElapsedTime="False" ...
+		 FilterLanguage="English" DateFormatString="d" ShowStatusBar="True" ShowElapsedTime="False" ShowClearFilterButton="True" ...
 		```   
 		- Properties
 		  - **ShowStatusBar** : *displays the status bar*, default : false
@@ -43,6 +43,7 @@ To understand how the filter works, you can consult the article posted on [CodeP
 		  - **DateFormatString** : *date display format*, default : "d"  
 [see the documentation "Standard date and time format strings"](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings)
 		  - **FilterLanguage** : *translation into available language*, default : English   
+		  - **ShowClearFilterButton** : *displays a button in the column header to clear the filter directly*, default : false
 
 		>  
 


### PR DESCRIPTION
As could be seen in the image below, I've included a button to clear the filter in the header. It is only visible if the filter of the column is set and if the option `ShowClearFilterButton="True"` is set in the FilterDataGrid.

Preview: 
![grafik](https://user-images.githubusercontent.com/31316050/142983776-648e0e08-124d-406e-af88-caee8a800695.png)

