### PR TITLE
Feature: filter preset

### DIFF
--- a/FilterDataGrid.Net/FilterCommon.cs
+++ b/FilterDataGrid.Net/FilterCommon.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -30,6 +31,7 @@ namespace FilterDataGrid
         public FilterCommon()
         {
             PreviouslyFilteredItems = new HashSet<object>(EqualityComparer<object>.Default);
+            Criteria = new HashSet<Predicate<object>>();
         }
 
         #endregion Public Constructors
@@ -52,6 +54,7 @@ namespace FilterDataGrid
         }
 
         public HashSet<object> PreviouslyFilteredItems { get; set; }
+        public HashSet<Predicate<object>> Criteria { get; set; }
 
         public Loc Translate { get; set; }
 
@@ -62,7 +65,7 @@ namespace FilterDataGrid
         /// <summary>
         ///     Add the filter to the predicate dictionary
         /// </summary>
-        public void AddFilter(Dictionary<string, Predicate<object>> criteria)
+        public void AddFilter()
         {
             if (IsFiltered) return;
 
@@ -77,8 +80,7 @@ namespace FilterDataGrid
             }
 
             // add to list of predicates
-            criteria.Add(FieldName, Predicate);
-
+            Criteria.Add(Predicate);
             IsFiltered = true;
         }
 

--- a/FilterDataGrid.Net/FilterCommon.cs
+++ b/FilterDataGrid.Net/FilterCommon.cs
@@ -12,13 +12,13 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Newtonsoft.Json;
+using System.Runtime.Serialization;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
 namespace FilterDataGrid
 {
-    public sealed class FilterCommon : NotifyProperty
+    public sealed class FilterCommon : NotifyProperty, ISerializable
     {
         #region Private Fields
 
@@ -34,19 +34,23 @@ namespace FilterDataGrid
             Criteria = new HashSet<Predicate<object>>();
         }
 
+        protected FilterCommon(SerializationInfo info, StreamingContext context)
+        {
+            FieldName = info.GetString(nameof(FieldName));
+            FilteredItems = new HashSet<object>((object[])info.GetValue(nameof(FilteredItems), typeof(object[])));
+            IsFiltered = info.GetBoolean(nameof(IsFiltered));
+        }
+
         #endregion Public Constructors
 
         #region Public Properties
 
         public string FieldName { get; set; }
 
-        [JsonIgnore]
         public Type FieldType { get; set; }
 
-        [JsonIgnore]
         public PropertyInfo FieldProperty { get; set; }
 
-        [JsonIgnore]
         public bool IsFiltered
         {
             get => isFiltered;
@@ -59,10 +63,8 @@ namespace FilterDataGrid
 
         public HashSet<object> FilteredItems { get; set; }
 
-        [JsonIgnore]
         public HashSet<Predicate<object>> Criteria { get; set; }
 
-        [JsonIgnore]
         public Loc Translate { get; set; }
 
         #endregion Public Properties
@@ -98,6 +100,13 @@ namespace FilterDataGrid
             Criteria.Clear();
             isFiltered = false;
             return true;
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(FieldName), FieldName);
+            info.AddValue(nameof(FilteredItems), FilteredItems);
+            info.AddValue(nameof(IsFiltered), IsFiltered);
         }
 
         #endregion Public Methods

--- a/FilterDataGrid.Net/FilterCommon.cs
+++ b/FilterDataGrid.Net/FilterCommon.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
@@ -39,10 +39,14 @@ namespace FilterDataGrid
         #region Public Properties
 
         public string FieldName { get; set; }
+
+        [JsonIgnore]
         public Type FieldType { get; set; }
 
+        [JsonIgnore]
         public PropertyInfo FieldProperty { get; set; }
 
+        [JsonIgnore]
         public bool IsFiltered
         {
             get => isFiltered;
@@ -54,8 +58,11 @@ namespace FilterDataGrid
         }
 
         public HashSet<object> PreviouslyFilteredItems { get; set; }
+
+        [JsonIgnore]
         public HashSet<Predicate<object>> Criteria { get; set; }
 
+        [JsonIgnore]
         public Loc Translate { get; set; }
 
         #endregion Public Properties
@@ -65,7 +72,7 @@ namespace FilterDataGrid
         /// <summary>
         ///     Add the filter to the predicate dictionary
         /// </summary>
-        public void AddFilter()
+        public void AddCriteria()
         {
             if (IsFiltered) return;
 
@@ -82,6 +89,15 @@ namespace FilterDataGrid
             // add to list of predicates
             Criteria.Add(Predicate);
             IsFiltered = true;
+        }
+
+        public bool RemoveFilter()
+        {
+            if (!IsFiltered) return false;
+
+            Criteria.Clear();
+            isFiltered = false;
+            return true;
         }
 
         #endregion Public Methods

--- a/FilterDataGrid.Net/FilterCommon.cs
+++ b/FilterDataGrid.Net/FilterCommon.cs
@@ -30,7 +30,7 @@ namespace FilterDataGrid
 
         public FilterCommon()
         {
-            PreviouslyFilteredItems = new HashSet<object>(EqualityComparer<object>.Default);
+            FilteredItems = new HashSet<object>(EqualityComparer<object>.Default);
             Criteria = new HashSet<Predicate<object>>();
         }
 
@@ -57,7 +57,7 @@ namespace FilterDataGrid
             }
         }
 
-        public HashSet<object> PreviouslyFilteredItems { get; set; }
+        public HashSet<object> FilteredItems { get; set; }
 
         [JsonIgnore]
         public HashSet<Predicate<object>> Criteria { get; set; }
@@ -83,7 +83,7 @@ namespace FilterDataGrid
                     ? ((DateTime?)FieldProperty?.GetValue(o, null))?.Date
                     : FieldProperty?.GetValue(o, null);
 
-                return !PreviouslyFilteredItems.Contains(value);
+                return FilteredItems.Contains(value);
             }
 
             // add to list of predicates

--- a/FilterDataGrid.Net/FilterDataGrid.Net.csproj
+++ b/FilterDataGrid.Net/FilterDataGrid.Net.csproj
@@ -77,6 +77,9 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
 
 
 </Project>

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -328,9 +328,9 @@ namespace FilterDataGrid
             }
         }
 
-        public string FilterPreset
+        public ObservableCollection<FilterCommon> FilterPreset
         {
-            get => (string)GetValue(FilterPresetProperty);
+            get => new ObservableCollection<FilterCommon>(GlobalFilterList);
             set => SetValue(FilterPresetProperty, value);
         }
 
@@ -341,7 +341,7 @@ namespace FilterDataGrid
         private FilterCommon CurrentFilter { get; set; }
         private ICollectionView CollectionViewSource { get; set; }
         private ICollectionView ItemCollectionView { get; set; }
-        private List<FilterCommon> GlobalFilterList { get; } = new List<FilterCommon>();
+        private List<FilterCommon> GlobalFilterList { get; set; } = new List<FilterCommon>();
 
         /// <summary>
         /// Popup filtered items (ListBox/TreeView)
@@ -360,7 +360,17 @@ namespace FilterDataGrid
         #region Protected Methods
         protected static void FilterPresetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-
+            var filterDataGrid = (FilterDataGrid)d;
+            
+            //remove all existing filters
+            filterDataGrid.RemoveAllFilterCommand(null, null); 
+            
+            //loop through the filters in the preset and apply them
+            foreach (FilterCommon filter in (ObservableCollection<FilterCommon>)e.NewValue) 
+            {
+                filterDataGrid.CurrentFilter = filter;
+                filterDataGrid.ApplyFilterCommand(null, null);
+            }
         }
 
 

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -136,6 +137,15 @@ namespace FilterDataGrid
                 typeof(bool),
                 typeof(FilterDataGrid),
                 new PropertyMetadata(false));
+
+        /// <summary>
+        ///     Get or set a filter preset
+        /// </summary>
+        public static readonly DependencyProperty FilterPresetProperty =
+            DependencyProperty.Register("FilterPreset",
+                typeof(ObservableCollection<FilterCommon>),
+                typeof(FilterDataGrid),
+                new PropertyMetadata(new ObservableCollection<FilterCommon>(), FilterPresetChanged));
 
         #endregion Public DependencyProperty
 
@@ -318,6 +328,12 @@ namespace FilterDataGrid
             }
         }
 
+        public string FilterPreset
+        {
+            get => (string)GetValue(FilterPresetProperty);
+            set => SetValue(FilterPresetProperty, value);
+        }
+
         #endregion Public Properties
 
         #region Private Properties
@@ -342,6 +358,11 @@ namespace FilterDataGrid
         #endregion Private Properties
 
         #region Protected Methods
+        protected static void FilterPresetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+
+        }
+
 
         // CALL ORDER :
         // Constructor

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -74,7 +74,6 @@ namespace FilterDataGrid
         #region Command
 
         public static readonly ICommand ApplyFilter = new RoutedCommand();
-        public static readonly ICommand ApplyAllFilter = new RoutedCommand();
         public static readonly ICommand CancelFilter = new RoutedCommand();
         public static readonly ICommand ClearSearchBox = new RoutedCommand();
         public static readonly ICommand IsChecked = new RoutedCommand();
@@ -139,15 +138,6 @@ namespace FilterDataGrid
                 typeof(bool),
                 typeof(FilterDataGrid),
                 new PropertyMetadata(false));
-
-        /// <summary>
-        ///     Get or set a filter preset
-        /// </summary>
-        public static readonly DependencyProperty FilterPresetProperty =
-            DependencyProperty.Register("FilterPreset",
-                typeof(ObservableCollection<FilterCommon>),
-                typeof(FilterDataGrid),
-                new PropertyMetadata(new ObservableCollection<FilterCommon>()));
 
         #endregion Public DependencyProperty
 

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -552,7 +552,6 @@ namespace FilterDataGrid
             foreach (FilterCommon filter in filterPreset.ToList())
             {
                 //gather missing information that could not be serialized
-                filter.AddCriteria();
                 var fieldProperty = collectionType.GetProperty(filter.FieldName);
                 if (fieldProperty != null)
                     fieldType = Nullable.GetUnderlyingType(fieldProperty.PropertyType) ?? fieldProperty.PropertyType;
@@ -565,12 +564,9 @@ namespace FilterDataGrid
                     FieldProperty = fieldProperty,
                     FieldType = fieldType,
                     PreviouslyFilteredItems = filter.PreviouslyFilteredItems,
-                    IsFiltered = true,
-                    Criteria = filter.Criteria,
+                    IsFiltered = false,
                     Translate = Translate
                 };
-
-                GlobalFilterList.Add(CurrentFilter);
 
                 //apply current filter
                 ApplyFilterCommand(null, null);

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -173,6 +173,7 @@ namespace FilterDataGrid
         private Popup popup;
 
         private string fieldName;
+        private string lastFilter;
         private string searchText;
         private TextBox searchTextBox;
         private Thumb thumb;
@@ -1149,9 +1150,11 @@ namespace FilterDataGrid
             searchLength = searchText.Length;
             search = !string.IsNullOrEmpty(searchText);
 
-            if (CurrentFilter.FieldType == typeof(DateTime) || treeView == null)
+            // apply filter
+            ItemCollectionView.Refresh();
+
+            if (CurrentFilter.FieldType == typeof(DateTime))
             {
-                // rebuild treeView rebuild treeView
                 if (string.IsNullOrEmpty(searchText))
                 {
                     // fill the tree with the elements of the list of the original items
@@ -1161,23 +1164,22 @@ namespace FilterDataGrid
                 {
                     // fill the tree only with the items found by the search
                     var items = PopupViewItems.Where(i => i.IsChecked).ToList();
-
                     // if at least one item is not null, fill in the tree structure otherwise the tree structure contains only the item (select all).
                     TreeViewItems = BuildTree(items.Any() ? items : null);
                 }
             }
             else
             {
-                //rebuild listboxitems
+                // rebuild listboxitems
                 if (string.IsNullOrEmpty(searchText))
+                {
                     ListBoxItems = SourcePopupViewItems.ToList();
+                }
                 else
+                {
                     ListBoxItems = PopupViewItems.Where(i => i.IsChecked).ToList();
+                }
             }
-            
-
-            // apply filter
-            ItemCollectionView.Refresh();
         }
 
         /// <summary>

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -26,6 +26,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace FilterDataGrid
 {
@@ -165,6 +166,7 @@ namespace FilterDataGrid
         private Grid sizableContentGrid;
 
         private List<string> excludedFields;
+        private Dictionary<string, FilterItem> filterableItems;
         private List<FilterItemDate> treeView;
         private List<FilterItem> listBoxItems;
 
@@ -533,7 +535,6 @@ namespace FilterDataGrid
         #endregion Protected Methods
 
         #region Private Methods
-
         //apply the filterpreset that is saved earlier
         private void OnFilterPresetChanged(List<FilterCommon> filterPreset)
         {
@@ -541,8 +542,17 @@ namespace FilterDataGrid
 
             foreach (FilterCommon filter in filterPreset.ToList())
             {
+
+                PropertyInfo fieldProperty = ItemsSource.Cast<object>()?
+                                               .FirstOrDefault()?
+                                               .GetType()
+                                               .GetProperty(filter.FieldName);
+                //foreach (var item in ItemsSource[0])
+                //{
+                //    fieldProperty = if (item.GetType().GetProperty(filter.FieldName)
+                //}
                 //gather missing information that could not be serialized
-                var fieldProperty = collectionType.GetProperty(filter.FieldName);
+                //var fieldProperty = collectionType.GetProperty(filter.FieldName);
                 if (fieldProperty != null)
                     fieldType = Nullable.GetUnderlyingType(fieldProperty.PropertyType) ?? fieldProperty.PropertyType;
 
@@ -553,7 +563,7 @@ namespace FilterDataGrid
                     FieldName = filter.FieldName,
                     FieldProperty = fieldProperty,
                     FieldType = fieldType,
-                    PreviouslyFilteredItems = filter.PreviouslyFilteredItems,
+                    FilteredItems = filter.FilteredItems,
                     IsFiltered = false,
                     Translate = Translate
                 };
@@ -593,7 +603,7 @@ namespace FilterDataGrid
                 foreach (var y in dateTimes.Where(c => c.Level == 1)
                              .Select(filterItem => new
                              {
-                                 ((DateTime)filterItem.Content).Date,
+                                 DateTime.Parse(filterItem.Content.ToString()).Date,
                                  Item = filterItem
                              })
                              .GroupBy(g => g.Date.Year)
@@ -1141,7 +1151,7 @@ namespace FilterDataGrid
             var textBox = (TextBox)sender;
 
             // fix TextChanged event fires twice I did not find another solution
-            if (textBox == null || textBox.Text == searchText || ItemCollectionView == null) return;
+            if (textBox == null || textBox.Text == searchText) return;
 
             searchText = textBox.Text;
 
@@ -1191,7 +1201,7 @@ namespace FilterDataGrid
             {
                 // filter button
                 Button button = (Button)e.OriginalSource;
-                if (Items.Count == 0 || button == null) return;
+                if (button == null) return;
 
                 // contribution : OTTOSSON
                 // for the moment this functionality is not tested, I do not know if it can cause unexpected effects
@@ -1269,67 +1279,64 @@ namespace FilterDataGrid
                     //currentColumn = column;
                 }
 
-                // invalid fieldName
-                if (string.IsNullOrEmpty(fieldName)) return;
 
-                // get type of field
-                fieldType = null;
-                var fieldProperty = collectionType.GetProperty(fieldName);
+                if(CurrentFilter is null)
+                {
+                    // invalid fieldName
+                    if (string.IsNullOrEmpty(fieldName)) return;
 
-                // get type or underlying type if nullable
-                if (fieldProperty != null)
-                    FieldType = Nullable.GetUnderlyingType(fieldProperty.PropertyType) ?? fieldProperty.PropertyType;
+                    // get type of field
+                    fieldType = null;
+                    var fieldProperty = collectionType.GetProperty(fieldName);
 
-                // If no filter, add filter to GlobalFilterList list
-                CurrentFilter = GlobalFilterList.FirstOrDefault(f => f.FieldName == fieldName) ??
-                                new FilterCommon
-                                {
-                                    FieldName = fieldName,
-                                    FieldType = fieldType,
-                                    Translate = Translate,
-                                    FieldProperty = fieldProperty
-                                };
+                    // get type or underlying type if nullable
+                    if (fieldProperty != null)
+                        FieldType = Nullable.GetUnderlyingType(fieldProperty.PropertyType) ?? fieldProperty.PropertyType;
 
-                // list of all item values, filtered and unfiltered (previous filtered items)
-                var sourceObjectList = new List<object>();
+                    // If no filter, add filter to GlobalFilterList list
+                    CurrentFilter = GlobalFilterList.FirstOrDefault(f => f.FieldName == fieldName) ??
+                                    new FilterCommon
+                                    {
+                                        FieldName = fieldName,
+                                        FieldType = fieldType,
+                                        Translate = Translate,
+                                        FieldProperty = fieldProperty
+                                    };
+                }
 
                 // set cursor
                 Mouse.OverrideCursor = Cursors.Wait;
-
-                List<FilterItem> filterItemList = null;//new List<FilterItem>();
-
-                // get the list of values distinct from the list of raw values of the current column
+                
+                
                 await Task.Run(() =>
-                {
-                    // contribution : STEFAN HEIMEL
-                    Dispatcher.Invoke(() =>
+                { 
+                    // gather all values that are in the column of a certain fieldName
+                    List<object> sourceObjectList = new List<object>();
+
+                    foreach (var item in ItemsSource)
                     {
+                        //get all values for the popup based on a fieldName
+                        object propertyValue = null;
                         if (fieldType == typeof(DateTime))
-                            // possible distinct values because time part is removed
-                            sourceObjectList = Items.Cast<object>()
-                                .Select(x => (object)((DateTime?)fieldProperty?.GetValue(x, null))?.Date)
-                                .Distinct()
-                                .ToList();
+                            propertyValue = (object)FilterHelper.GetPropertyValue<DateTime>(item, fieldName).Date.ToString("yyyy/MM/dd");
                         else
-                            sourceObjectList = Items.Cast<object>()
-                                .Select(x => fieldProperty?.GetValue(x, null))
-                                .Distinct()
-                                .ToList();
-                    });
+                            propertyValue = FilterHelper.GetPropertyValue<string>(item, fieldName);
+                        
+                        //check if there are any empty values, do not add them to the popup
+                        if (string.IsNullOrEmpty((string)propertyValue)) continue;
 
-                    // adds the previous filtered items to the list of new items (CurrentFilter.PreviouslyFilteredItems)
-                    sourceObjectList.AddRange(CurrentFilter?.PreviouslyFilteredItems ?? new HashSet<object>());
-
-                    // empty item flag
-                    // if they exist, remove all null or empty string values from the list.
-                    // content == null and content == "" are two different things but both labeled as (blank)
-                    var emptyItem = sourceObjectList.RemoveAll(v => v == null || v.Equals(string.Empty)) > 0;
-
-                    // TODO : AggregateException when user can add row
+                        //only add distinct values, so only if they do not exist
+                        if (!sourceObjectList.Contains(propertyValue))
+                        {
+                            sourceObjectList.Add(propertyValue);
+                        }
+                    }
 
                     // sorting is a very slow operation, using ParallelQuery
                     sourceObjectList = sourceObjectList.AsParallel().OrderBy(x => x).ToList();
 
+                    //convert the sourceObjectList to a filterItem that is used in the popup
+                    List<FilterItem> filterItemList = new List<FilterItem>();
                     if (fieldType == typeof(bool))
                     {
                         filterItemList = new List<FilterItem>(sourceObjectList.Count + 1);
@@ -1345,26 +1352,23 @@ namespace FilterDataGrid
 
                     // add all items (not null) to the filterItemList,
                     // the list of dates is calculated by BuildTree from this list
-                    filterItemList.AddRange(sourceObjectList.Select(item => new FilterItem
-                    {
-                        Content = item,
-                        ContentLength = item?.ToString()?.Length ?? 0,
-                        FieldType = fieldType,
-                        Label = item,
-                        Level = 1,
-                        Initialize = CurrentFilter.PreviouslyFilteredItems?.Contains(item) == false
-                    }));
+                    filterItemList.AddRange(sourceObjectList.Select(item => 
+                        new FilterItem
+                        {
+                            Content = item,
+                            ContentLength = item?.ToString()?.Length ?? 0,
+                            FieldType = fieldType,
+                            Label = item,
+                            Level = 1,
+                            Initialize = CurrentFilter.FilteredItems.Count <= 0 ? true : CurrentFilter.FilteredItems?.Contains(item) == true
+                        }
+                    ));
 
                     if (fieldType == typeof(bool))
                         filterItemList.ToList().ForEach(c =>
                         {
-                            c.Label = (bool)c.Content ? Translate.IsTrue : Translate.IsFalse;
+                            c.Label = bool.Parse(c.Content.ToString()) ? Translate.IsTrue : Translate.IsFalse;
                         });
-
-                    // add a empty item(if exist) at the bottom of the list
-                    if (!emptyItem) return;
-
-                    sourceObjectList.Insert(sourceObjectList.Count, null);
 
                     filterItemList.Add(new FilterItem
                     {
@@ -1372,21 +1376,21 @@ namespace FilterDataGrid
                         Content = null,
                         Label = Translate.Empty,
                         Level = -1,
-                        Initialize = CurrentFilter?.PreviouslyFilteredItems?.Contains(null) == false
+                        Initialize = CurrentFilter?.FilteredItems?.Contains(null) == false
                     });
+
+                    // ItemsSource (ListBow/TreeView)
+                    if (fieldType == typeof(DateTime))
+                        TreeViewItems = BuildTree(filterItemList);
+                    else
+                        ListBoxItems = filterItemList;
+
+                    // Set ICollectionView for filtering in the pop-up window
+                    ItemCollectionView = System.Windows.Data.CollectionViewSource.GetDefaultView(filterItemList);
+
+                    // set filter in popup
+                    if (ItemCollectionView.CanFilter) ItemCollectionView.Filter = SearchFilter;
                 });
-
-                // ItemsSource (ListBow/TreeView)
-                if (fieldType == typeof(DateTime))
-                    TreeViewItems = BuildTree(filterItemList);
-                else
-                    ListBoxItems = filterItemList;
-
-                // Set ICollectionView for filtering in the pop-up window
-                ItemCollectionView = System.Windows.Data.CollectionViewSource.GetDefaultView(filterItemList);
-
-                // set filter in popup
-                if (ItemCollectionView.CanFilter) ItemCollectionView.Filter = SearchFilter;
 
                 // set the placement and offset of the PopUp in relation to the header and the main window of the application
                 // i.e (placement : bottom left or bottom right)
@@ -1443,54 +1447,21 @@ namespace FilterDataGrid
                 {
                     Task.Run(() =>
                     {
-                        var previousFiltered = CurrentFilter.PreviouslyFilteredItems;
-                        bool blankIsUnchecked = false; //preset value to default
-
+                        
                         bool frontendFilterChanged = PopupViewItems.Any(c => c.IsChanged);
                         if (frontendFilterChanged)
                         {
                             if (search)
                             {
-                                // result of the research
-                                var searchResult = PopupViewItems.Where(c => c.IsChecked).ToList();
-
-                                // unchecked : all items except searchResult
-                                var uncheckedItems = SourcePopupViewItems.Except(searchResult).ToList();
-                                uncheckedItems.AddRange(searchResult.Where(c => c.IsChecked == false));
-
-                                previousFiltered.ExceptWith(searchResult.Select(c => c.Content));
-
-                                previousFiltered.UnionWith(uncheckedItems.Select(c => c.Content));
-
-                                blankIsUnchecked = uncheckedItems.Any(c => c.Level == -1);
+                                CurrentFilter.FilteredItems = PopupViewItems.Where(c => c.IsChecked)
+                                                                       .Select(c => c.Content)
+                                                                       .ToHashSet();
                             }
                             else
                             {
-                                // changed popup items
-                                var changedItems = PopupViewItems.Where(c => c.IsChanged).ToList();
-
-                                var checkedItems = changedItems.Where(c => c.IsChecked);
-                                var uncheckedItems = changedItems.Where(c => !c.IsChecked).ToList();
-
-                                // previous item except unchecked items checked again
-                                previousFiltered.ExceptWith(checkedItems.Select(c => c.Content));
-                                previousFiltered.UnionWith(uncheckedItems.Select(c => c.Content));
-
-                                blankIsUnchecked = uncheckedItems.Any(c => c.Level == -1);
-                            }
-
-                            // two values, null and string.empty
-                            if (CurrentFilter.FieldType != typeof(DateTime) &&
-                                previousFiltered.Any(c => c == null || c.ToString() == string.Empty))
-                            {
-                                // if (blank) item is unchecked, add string.Empty.
-                                // at this step, the null value is already added previously
-                                if (blankIsUnchecked)
-                                    previousFiltered.Add(string.Empty);
-
-                                // if (blank) item is rechecked, remove string.Empty.
-                                else
-                                    previousFiltered.RemoveWhere(item => item?.ToString() == string.Empty);
+                                CurrentFilter.FilteredItems = PopupViewItems.Where(c => c.IsChecked)
+                                                                        .Select(c => c.Content)
+                                                                        .ToHashSet();
                             }
                         }
 
@@ -1509,7 +1480,7 @@ namespace FilterDataGrid
                     CollectionViewSource.Refresh();
 
                     // remove the current filter if there is no items to filter
-                    if (!CurrentFilter.PreviouslyFilteredItems.Any())
+                    if (!CurrentFilter.FilteredItems.Any())
                         RemoveCurrentFilter();
 
                     var col = Columns.FirstOrDefault(c => (c is DataGridTextColumn dtx && dtx.IsColumnFiltered && dtx.FieldName == CurrentFilter?.FieldName)

--- a/FilterDataGrid.Net/FilterHelpers.cs
+++ b/FilterDataGrid.Net/FilterHelpers.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -53,6 +54,34 @@ namespace FilterDataGrid
         }
 
         #endregion Public Methods
+    }
+
+    public static class FilterHelper
+    {
+        public static T GetPropertyValue<T>(object item, string fieldName)
+        {
+            Type itemType = item.GetType();
+            PropertyInfo propertyInfo = itemType.GetProperty(fieldName);
+
+            if(propertyInfo != null)
+            {
+                object propertyValue = propertyInfo.GetValue(item);
+
+                if(propertyValue != null)
+                {
+                    if(propertyValue is T typedValue)
+                    {
+                        return typedValue;
+                    }
+                    else if (typeof(T) == typeof(string))
+                    {
+                        return (T)(object)propertyValue.ToString();
+                    }
+                }
+            }
+
+            return default(T);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
closes #108 with working prototype. 

**advantages:** 
- I have example code in the image below that works using a jsonserializer.
[Imgur image](https://imgur.com/l2ozQbK)
The button `Button_Write_Click` saves the filterpreset to a json file and the `Button_Read_Click` reads the filterpreset from the json file and applies it on the datagrid.

**disadvantages**:
- the package will depend on `Newtonsoft.json`, because we need `[JsonIgnore]` attributes on the FilterCommon class

**video:**
you can watch the video of how it works here:
- https://youtu.be/1Box0_oVUJo
- it waits for 5 seconds before it filters, so it is not slow even though it looks like