### PR TITLE
Use Header's Content instead of converting it to String

### DIFF
--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -505,7 +505,7 @@ namespace FilterDataGrid
                         ItemsSource = ((System.Windows.Controls.DataGridComboBoxColumn)e.Column).ItemsSource,
                         SelectedItemBinding = new Binding(e.PropertyName),
                         FieldName = e.PropertyName,
-                        Header = e.Column.Header.ToString(),
+                        Header = e.Column.Header,
                         HeaderTemplate = template,
                         IsSingle = false, // eNum is not a unique value (unique identifier)
                         IsColumnFiltered = true
@@ -519,7 +519,7 @@ namespace FilterDataGrid
                     {
                         Binding = new Binding(e.PropertyName) { ConverterCulture = Translate.Culture },
                         FieldName = e.PropertyName,
-                        Header = e.Column.Header.ToString(),
+                        Header = e.Column.Header,
                         HeaderTemplate = template,
                         IsColumnFiltered = true
                     };
@@ -532,7 +532,7 @@ namespace FilterDataGrid
                     {
                         Binding = new Binding(e.PropertyName) { ConverterCulture = Translate.Culture },
                         FieldName = e.PropertyName,
-                        Header = e.Column.Header.ToString(),
+                        Header = e.Column.Header,
                         IsColumnFiltered = true
                     };
 

--- a/FilterDataGrid.Net/Themes/Generic.xaml
+++ b/FilterDataGrid.Net/Themes/Generic.xaml
@@ -450,8 +450,8 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <!--  RENDER THE HEADER TEXT  -->
-                <TextBlock Grid.Column="0" Text="{Binding}" />
+                <!--  RENDER THE HEADER CONTENT -->
+                <ContentPresenter Grid.Column="0" Content="{Binding}"/>
 
                 <!--
                     FILTER BUTTON


### PR DESCRIPTION
Imagine you have a header in a Column, which is not regular text but some control, like TextBox or maybe something even more complex. Current implementation tries to convert any Header's content with `ToString` which may end up with unreadable headers.

Here is potential Header defined with some TextBlock:
```xml
<control:DataGridTextColumn
    Binding="{Binding LastName}"
    IsColumnFiltered="True">
    <control:DataGridTextColumn.Header>
        <TextBlock Text="Last name" Margin="10">
            <TextBlock.LayoutTransform>
                <RotateTransform Angle="-90"/>
            </TextBlock.LayoutTransform>
        </TextBlock>
    </control:DataGridTextColumn.Header>
</control:DataGridTextColumn>
```

Instead of this from the `DemoApp.Net7.0`:
```xml
<control:DataGridTextColumn
    Binding="{Binding LastName}"
    Header="Last name"
    IsColumnFiltered="True" />
```

Current code ends up with next result:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/93c9ceae-5154-4023-8c72-853cfc3aa75e">

My PR is going to fix that and display the content from Header as-is.
<img width="482" alt="image" src="https://github.com/user-attachments/assets/0d9870a5-ad31-4541-afb9-5702825eab95">
