### PR TITLE
Fix filtering issue if DataContext was assigned before initialization

### DIFF
--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -451,6 +451,8 @@ namespace FilterDataGrid
                     excludedFields = ExcludeFields.Split(',').Select(p => p.Trim()).ToList();
                     excludedColumns = ExcludeColumns.Split(',').Select(p => p.Trim()).ToList();
                 }
+                // generating custom columns
+                else if (collectionType != null) GeneratingCustomsColumn();
 
                 // sorting event
                 Sorted += OnSorted;


### PR DESCRIPTION
During usage of DataGridFilter I've found one issue with manually added filtered columns.
In case if ViewModel of View was assigned before initialization - columns have no filter capabilities.
In such case of ViewModel usage OnItemsSourceChanged is called before OnInitialized, and Columns collection is empty at that time.
To reproduce this issue I've changed Demo project - https://github.com/macgile/DataGridFilter/compare/main...oleluo:DataGridFilter:dataContextIssueDemo

Fix could be different, but in my case I've used like in this PR: try to call GeneratingCustomsColumn in OnInitialized method.

Please try to reproduce the issue (just check my commit in branch dataContextIssueDemo and you will see no filter for custom columns, only for autogenerated ones) and check proposed fix.

Thanks.