### PR TITLE
Add DataGridBoundColumn with filtering capabilities

### DIFF
--- a/FilterDataGrid.Net/DataGridColumn.cs
+++ b/FilterDataGrid.Net/DataGridColumn.cs
@@ -432,4 +432,75 @@ namespace FilterDataGrid
 
         #endregion Public Properties
     }
+
+    public sealed class DataGridBoundColumn : System.Windows.Controls.DataGridBoundColumn
+    {
+        #region Public Fields
+
+        /// <summary>
+        /// FieldName Dependency Property.
+        /// </summary>
+        public static readonly DependencyProperty FieldNameProperty =
+            DependencyProperty.Register(nameof(FieldName), typeof(string), typeof(DataGridTextColumn),
+                new PropertyMetadata(""));
+
+        /// <summary>
+        /// IsColumnFiltered Dependency Property.
+        /// </summary>
+        public static readonly DependencyProperty IsColumnFilteredProperty =
+            DependencyProperty.Register(nameof(IsColumnFiltered), typeof(bool), typeof(DataGridTextColumn),
+                new PropertyMetadata(false));
+
+        #endregion Public Fields
+
+        #region Public Properties
+
+        public string FieldName
+        {
+            get => (string)GetValue(FieldNameProperty);
+            set => SetValue(FieldNameProperty, value);
+        }
+
+        public bool IsColumnFiltered
+        {
+            get => (bool)GetValue(IsColumnFilteredProperty);
+            set => SetValue(IsColumnFilteredProperty, value);
+        }
+
+        #endregion Public Properties
+
+        #region GenerateElement
+
+        public string TemplateName { get; set; }
+
+        protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
+        {
+            Binding binding;
+
+            ContentControl content = new ContentControl()
+            {
+                ContentTemplate = (DataTemplate)cell.FindResource(TemplateName)
+            };
+
+            if (Binding != null)
+            {
+                binding = new Binding(((Binding)Binding).Path.Path)
+                {
+                    Source = dataItem,
+                    Mode = BindingMode.TwoWay,
+                    NotifyOnSourceUpdated = true,
+                    NotifyOnTargetUpdated = true,
+                    UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+                };
+
+                content.SetBinding(ContentControl.ContentProperty, binding);
+            }
+
+            return content;
+        }
+
+        protected override FrameworkElement GenerateEditingElement(DataGridCell cell, object dataItem) => GenerateElement(cell, dataItem);
+
+        #endregion GenerateElement
+    }
 }

--- a/FilterDataGrid.Net/FilterDataGrid.cs
+++ b/FilterDataGrid.Net/FilterDataGrid.cs
@@ -79,7 +79,7 @@ namespace FilterDataGrid
         {
             // Register class handler to handle "LoadedEvent" event of "FrameworkContentElement"
             // OnLoaded method is used to load the filter persistence json file
-            EventManager.RegisterClassHandler(typeof(FilterDataGrid), 
+            EventManager.RegisterClassHandler(typeof(FilterDataGrid),
                 FrameworkElement.LoadedEvent, new RoutedEventHandler(OnLoaded));
         }
 
@@ -707,7 +707,7 @@ namespace FilterDataGrid
         protected override void OnLoadingRow(DataGridRowEventArgs e)
         {
             if(ShowRowsCount)
-            e.Row.Header = (e.Row.GetIndex() + 1).ToString();
+                e.Row.Header = (e.Row.GetIndex() + 1).ToString();
         }
 
         #endregion Protected Methods
@@ -833,7 +833,8 @@ namespace FilterDataGrid
                 {
                     var columns = Columns
                         .Where(c =>
-                            (c is DataGridTextColumn dtx && dtx.IsColumnFiltered & (dtx.FieldName == preset.FieldName))
+                            (c is DataGridBoundColumn dbu && dbu.IsColumnFiltered & (dbu.FieldName == preset.FieldName))
+                            || (c is DataGridTextColumn dtx && dtx.IsColumnFiltered & (dtx.FieldName == preset.FieldName))
                             || (c is DataGridTemplateColumn dtp && dtp.IsColumnFiltered & (dtp.FieldName == preset.FieldName))
                             || (c is DataGridCheckBoxColumn dck && dck.IsColumnFiltered & (dck.FieldName == preset.FieldName))
                             || (c is DataGridNumericColumn dnm && dnm.IsColumnFiltered & (dnm.FieldName == preset.FieldName))
@@ -1077,7 +1078,8 @@ namespace FilterDataGrid
                 // get the columns that can be filtered
                 // ReSharper disable MergeIntoPattern
                 var columns = Columns
-                    .Where(c => ((c is DataGridCheckBoxColumn dcb && dcb.IsColumnFiltered)
+                    .Where(c => ((c is DataGridBoundColumn dbu && dbu.IsColumnFiltered)
+                                  || (c is DataGridCheckBoxColumn dcb && dcb.IsColumnFiltered)
                                   || (c is DataGridComboBoxColumn dbx && dbx.IsColumnFiltered)
                                   || (c is DataGridNumericColumn dnm && dnm.IsColumnFiltered)
                                   || (c is DataGridTemplateColumn dtp && dtp.IsColumnFiltered)
@@ -1129,6 +1131,34 @@ namespace FilterDataGrid
                                     nameof(DataGridTemplateColumn));
                             // template
                             column.HeaderTemplate = template;
+                        }
+
+                        if (columnType == typeof(DataGridBoundColumn))
+                        {
+                            var column = (DataGridBoundColumn)col;
+
+                            column.FieldName = ((Binding)column.Binding).Path.Path;
+
+                            // template
+                            column.HeaderTemplate = template;
+
+                            var fieldProperty = collectionType.GetProperty(((Binding)column.Binding).Path.Path);
+
+                            // get type or underlying type if nullable
+                            if (fieldProperty != null)
+                                fieldType = Nullable.GetUnderlyingType(fieldProperty.PropertyType) ??
+                                            fieldProperty.PropertyType;
+
+                            // apply DateFormatString when StringFormat for column is not provided or empty
+                            if (fieldType == typeof(DateTime) && !string.IsNullOrEmpty(DateFormatString))
+                                if (string.IsNullOrEmpty(column.Binding.StringFormat))
+                                    column.Binding.StringFormat = DateFormatString;
+
+                            FieldType = fieldType;
+
+                            // culture
+                            if (((Binding)column.Binding).ConverterCulture == null)
+                                ((Binding)column.Binding).ConverterCulture = Translate.Culture;
                         }
 
                         if (columnType == typeof(DataGridTextColumn))
@@ -1661,6 +1691,10 @@ namespace FilterDataGrid
                 if (headerColumn is DataGridTextColumn textColumn)
                 {
                     fieldName = textColumn.FieldName;
+                }
+                if (headerColumn is DataGridBoundColumn templateBound)
+                {
+                    fieldName = templateBound.FieldName;
                 }
                 if (headerColumn is DataGridTemplateColumn templateColumn)
                 {


### PR DESCRIPTION
Added support to DataGridBoundColumn derived from DataGridTextColumn, it maintains all the filter functionalities but let the user create cell with a Control, so is easier to create autogenerated columns with all type of data and with external controls (like [wpftoolkit](https://github.com/xceedsoftware/wpftoolkit)).