### PR TITLE
Resolve a bug that occurs when you assign the ItemSource of type ObservableCollection<object>

### DIFF
--- a/FilterDataGrid.Net/FilterCommon.cs
+++ b/FilterDataGrid.Net/FilterCommon.cs
@@ -73,7 +73,7 @@ namespace FilterDataGrid
                     return null; // or a default type, e.g., typeof(object)
                 }
             }
-            set => FieldTypeString = value.AssemblyQualifiedName;
+            set => FieldTypeString = value?.AssemblyQualifiedName;
         }
         public bool IsFiltered
         {


### PR DESCRIPTION
Resolve a bug that occurs when you assign the ItemSource of type ObservableCollection<object>, everything keeps to works fine with this small correction expanding the scalability of the filterdatagrid

Fix null handling in FieldTypeString setter

Updated the FieldTypeString property setter to use a null-conditional operator. This change prevents potential NullReferenceExceptions by ensuring that FieldTypeString is set to null if the input value is null.